### PR TITLE
FUNCT prepend moka module to call handler name

### DIFF
--- a/src/moka_server.erl
+++ b/src/moka_server.erl
@@ -144,7 +144,7 @@ safe_handle_call({replace, ReplaceSpec, NewBehaviour}, _From, State) ->
     Description   = make_description(Module, ReplaceSpec),
 
     HandlerName =
-        start_call_handler(NewBehaviour, Description, HistoryServer, Count),
+        start_call_handler(NewBehaviour, {Module, Description}, HistoryServer, Count),
     {arity, Arity} = erlang:fun_info(NewBehaviour, arity),
 
     {reply, ok,
@@ -190,14 +190,14 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 
 %%%_* Private functions ================================================
 
-start_call_handler(Behaviour, CallDescription, HistoryServer, Count) ->
-    HandlerName = call_handler_name(CallDescription, Count),
+start_call_handler(Behaviour, {MokaMod, CallDescription}, HistoryServer, Count) ->
+    HandlerName = call_handler_name(MokaMod, CallDescription, Count),
     moka_call_handler:start_link(
       HandlerName, CallDescription, Behaviour, HistoryServer),
     HandlerName.
 
-call_handler_name({Mod, _}, Count) ->
-    list_to_atom(sel_string:format("~p_moka_call_handler_~p", [Mod, Count])).
+call_handler_name(Moka, {Mod, _}, Count) ->
+    list_to_atom(sel_string:format("~p_~p_moka_call_handler_~p", [Moka, Mod, Count])).
 
 modify_call_in_code({external, Mod, Funct}, Arity, HandlerName, AbsCode) ->
     moka_mod_utils:replace_remote_calls(

--- a/test/component/moka_server_tests.erl
+++ b/test/component/moka_server_tests.erl
@@ -48,11 +48,15 @@ concurrent_moka_test_() ->
      fun({_Apps, Moka1, Moka2}) ->
              {inorder,
               [?_test(moka:replace(Moka1, something, fun() -> bar end)),
+               ?_test(moka:replace(Moka1, external, something, fun() -> hoge end)),
                ?_test(moka:replace(Moka2, something, fun() -> baz end)),
+               ?_test(moka:replace(Moka2, external, something, fun() -> piyo end)),
                ?_test(moka:load(Moka1)),
                ?_test(moka:load(Moka2)),
                ?_assertEqual(bar, moka_server_tests_aux1:call_something()),
-               ?_assertEqual(baz, moka_server_tests_aux2:call_something())]}
+               ?_assertEqual(hoge, moka_server_tests_aux1:call_external()),
+               ?_assertEqual(baz, moka_server_tests_aux2:call_something()),
+               ?_assertEqual(piyo, moka_server_tests_aux2:call_external())]}
      end}.
 
 %%%_* Emacs ============================================================

--- a/test/component/moka_server_tests_aux1.erl
+++ b/test/component/moka_server_tests_aux1.erl
@@ -26,8 +26,11 @@
 -module(moka_server_tests_aux1).
 
 -export([call_something/0]).
+-export([call_external/0]).
 
 call_something() -> something().
+
+call_external() -> external:something().
 
 something() -> foo.
 

--- a/test/component/moka_server_tests_aux2.erl
+++ b/test/component/moka_server_tests_aux2.erl
@@ -26,8 +26,11 @@
 -module(moka_server_tests_aux2).
 
 -export([call_something/0]).
+-export([call_external/0]).
 
 call_something() -> something().
+
+call_external() -> external:something().
 
 something() -> foo.
 


### PR DESCRIPTION
hi @samuelrivas , thank you for the inspiring work of moka.

I am currently using moka in one of my projects, and some use cases make me think that it may be better to name the call handler gen_server as a combination of the moka, mocked module and mock count.

Here is one my my use case:
I have a `foo.erl` and `bar.erl`, in both modules, they call `baz:something()`. And I want `baz:something()` behaves differently in `foo.erl` and `bar.erl`. So I do:

``` erlang
Moka1 = moka:start(foo),
Moka2 = moka:start(bar),
moka:replace(Moka1, baz, something, fun() -> hoge end),
moka:replace(Moka2, baz, something, fun() -> piyo end),
```

This leads to same results of #16, since the call handler is name only after `baz`. So making it something like `foo_baz` and `bar_baz` should be the solution.
